### PR TITLE
Add support for SSL connection to Postgres/Redshift database

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -6,6 +6,7 @@ targets:
     port: 5439 # Default Redshift port
     username: ADD HERE
     password: ADD HERE
+    ssl: false # SSL disabled by default
 variables:
   foo: bar
 steps:

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -21,6 +21,7 @@ type Playbook struct {
 
 type Target struct {
 	Name, Type, Host, Database, Port, Username, Password string
+	Ssl bool
 }
 
 type Step struct {

--- a/run/postgres.go
+++ b/run/postgres.go
@@ -36,7 +36,7 @@ func NewPostgresTarget(target playbook.Target) *PostgresTarget {
 		User:        target.Username,
 		Password:    target.Password,
 		Database:    target.Database,
-		SSL:         false, // SSL is a problem for Redshift
+		SSL:         target.Ssl,
 		DialTimeout: dialTimeout,
 		ReadTimeout: readTimeout,
 	})


### PR DESCRIPTION
Modification required to enable the SQL runner to connect to AWS Redshift databases where the database's associated parameter group (http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html) only permits SSL connections (require_ssl: true).