### PR TITLE
Add support to passing variables as command-line options

### DIFF
--- a/integration-tests/postgres-sql/good/assert.sql
+++ b/integration-tests/postgres-sql/good/assert.sql
@@ -7,10 +7,10 @@ DECLARE
   expected_average_age CONSTANT integer := 25;
 BEGIN
   {{/* Update view names to today's date or Travis will error */}}
-  IF (SELECT average_age <> expected_average_age FROM {{.test_schema}}.view_2015_09_13) THEN
+  IF (SELECT average_age <> expected_average_age FROM {{.test_schema}}.view_2015_09_14) THEN
     RAISE EXCEPTION 'Average_age % does not match expected age %',
-    	(SELECT average_age FROM {{.test_schema}}.view_2015_09_13),
-    	expected_average_age;
+      (SELECT average_age FROM {{.test_schema}}.view_2015_09_14),
+      expected_average_age;
   END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	options := processFlags()
 
-	pb, err := playbook.ParsePlaybook(options.playbook)
+	pb, err := playbook.ParsePlaybook(options.playbook, options.variables)
 	if err != nil {
 		log.Fatalf("Could not parse playbook (YAML): %s", err.Error())
 	}
@@ -51,7 +51,7 @@ func main() {
 // required flag
 func processFlags() Options {
 
-	var options Options
+	var options Options = NewOptions()
 	var fs = options.GetFlagSet()
 	fs.Parse(os.Args[1:])
 

--- a/options.go
+++ b/options.go
@@ -15,22 +15,47 @@ package main
 import (
 	"flag"
 	"fmt"
+	"strings"
 )
 
+type CLIVariables map[string]string
+
+// Implement the Value interface
+func (i *CLIVariables) String() string {
+	return fmt.Sprintf("%s", *i)
+}
+
+func (i *CLIVariables) Set(value string) error {
+	var split = strings.SplitN(value, "=", 2)
+	if len(split) > 1 {
+		key := split[0]
+		val := split[1]
+		(*i)[key] = val
+	}
+	return nil
+}
+
 type Options struct {
-	help     bool
-	version  bool
-	playbook string
-	sqlroot  string
+	help      bool
+	version   bool
+	playbook  string
+	sqlroot   string
+	variables CLIVariables
+}
+
+func NewOptions() Options {
+	return Options{variables: make(map[string]string)}
 }
 
 func (o *Options) GetFlagSet() *flag.FlagSet {
+	o.variables = make(map[string]string)
 	var fs = flag.NewFlagSet("Options", flag.ContinueOnError)
 
 	fs.BoolVar(&(o.help), "help", false, "Shows this message")
 	fs.BoolVar(&(o.version), "version", false, "Shows the program version")
 	fs.StringVar(&(o.playbook), "playbook", "", "Playbook of SQL scripts to execute")
 	fs.StringVar(&(o.sqlroot), "sqlroot", SQLROOT_PLAYBOOK, fmt.Sprintf("Absolute path to SQL scripts. Use %s and %s for those respective paths", SQLROOT_PLAYBOOK, SQLROOT_BINARY))
+	fs.Var(&(o.variables), "var", "Variables to be passed to the playbook, in the key=value format")
 	// TODO: add format flag if/when we support TOML
 
 	return fs

--- a/options.go
+++ b/options.go
@@ -48,7 +48,6 @@ func NewOptions() Options {
 }
 
 func (o *Options) GetFlagSet() *flag.FlagSet {
-	o.variables = make(map[string]string)
 	var fs = flag.NewFlagSet("Options", flag.ContinueOnError)
 
 	fs.BoolVar(&(o.help), "help", false, "Shows this message")

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -35,7 +35,18 @@ type Query struct {
 }
 
 // Dispatch to format-specific parser
-func ParsePlaybook(filepath string) (Playbook, error) {
+func ParsePlaybook(filepath string, variables map[string]string) (Playbook, error) {
 	// TODO: Add TOML support?
-	return parsePlaybookYaml(filepath)
+	playbook, err := parsePlaybookYaml(filepath)
+	if err == nil {
+		playbook = MergeCLIVariables(playbook, variables)
+	}
+	return playbook, err
+}
+
+func MergeCLIVariables(playbook Playbook, variables map[string]string) (Playbook) {
+	for k, v := range variables {
+		playbook.Variables[k] = v
+	}
+	return playbook
 }

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -44,7 +44,7 @@ func ParsePlaybook(filepath string, variables map[string]string) (Playbook, erro
 	return playbook, err
 }
 
-func MergeCLIVariables(playbook Playbook, variables map[string]string) (Playbook) {
+func MergeCLIVariables(playbook Playbook, variables map[string]string) Playbook {
 	for k, v := range variables {
 		playbook.Variables[k] = v
 	}


### PR DESCRIPTION
This implements the option to pass variables to playbooks using command-line arguments.
- `-var key1=val1` gets passed as the variable `key1` having the value `val1`.
- Multiple key-value pairs can be passed by just repeating `-var`: `-var key1=val1 -var key2=val2`
- Command-line variables override those defined in the playbooks.
- The first equals sign (`=`) found marks the separation between key and values: this means a value can contain as many equals sign it wants to, but the key can't.