### PR TITLE
Add the possibility to template playbooks

### DIFF
--- a/integration/resources/good-postgres-with-template.yml
+++ b/integration/resources/good-postgres-with-template.yml
@@ -1,0 +1,18 @@
+:targets:
+  - :name: "My Postgres database 1"
+    :type: postgres
+    :host: {{.host}}
+    :database: sql_runner_tests_1
+    :port: 5432
+    :username: {{.username}}
+    :password: {{.password}}
+    :ssl: false # SSL disabled by default
+:variables:
+  :test_schema: sql_runner_tests
+  :timeFormat: "2006_01_02"
+:steps:
+  - :name: Create schema and table
+    :queries:
+      - :name: Create schema and table
+        :file: postgres-sql/good/1.sql
+        :template: true

--- a/integration/run_tests.sh
+++ b/integration/run_tests.sh
@@ -127,6 +127,12 @@ assert_ExitCodeForCommand "0" "${root}/sql-runner -checkLock ${root}/dist/integr
 assert_ExitCodeForCommand "5" "${root}/sql-runner -playbook ${root_key}/bad-mixed.yml -lock ${root}/dist/integration-lock -dryRun"
 assert_ExitCodeForCommand "0" "${root}/sql-runner -playbook ${root_key}/good-postgres.yml -var test_date=`date "+%Y_%m_%d"` -lock ${root}/dist/integration-lock -dryRun"
 
+# Test: Valid playbook which uses playbook template variables
+assert_ExitCodeForCommand "6" "${root}/sql-runner -playbook ${root_key}/good-postgres-with-template.yml -var password=,host=localhost"
+assert_ExitCodeForCommand "6" "${root}/sql-runner -playbook ${root_key}/good-postgres-with-template.yml"
+assert_ExitCodeForCommand "0" "${root}/sql-runner -playbook ${root_key}/good-postgres-with-template.yml -var username=postgres,password=,host=localhost"
+
+
 printf "==========================================================\n"
 printf " INTEGRATION TESTS SUCCESSFUL\n"
 printf "==========================================================\n"

--- a/sql_runner/consul_provider.go
+++ b/sql_runner/consul_provider.go
@@ -15,12 +15,14 @@ package main
 type ConsulPlaybookProvider struct {
 	consulAddress string
 	consulKey     string
+	variables 		CLIVariables
 }
 
-func NewConsulPlaybookProvider(consulAddress, consulKey string) *ConsulPlaybookProvider {
+func NewConsulPlaybookProvider(options Options) *ConsulPlaybookProvider {
 	return &ConsulPlaybookProvider{
-		consulAddress: consulAddress,
-		consulKey:     consulKey,
+		consulAddress: options.consul,
+		consulKey:     options.playbook,
+		variables: 		 options.variables,
 	}
 }
 
@@ -30,6 +32,6 @@ func (p ConsulPlaybookProvider) GetPlaybook() (*Playbook, error) {
 		return nil, err
 	}
 
-	playbook, pbErr := parsePlaybookYaml(lines)
+	playbook, pbErr := parsePlaybookYaml(lines, p.variables)
 	return &playbook, pbErr
 }

--- a/sql_runner/consul_provider.go
+++ b/sql_runner/consul_provider.go
@@ -15,14 +15,14 @@ package main
 type ConsulPlaybookProvider struct {
 	consulAddress string
 	consulKey     string
-	variables 		CLIVariables
+	variables     map[string]string
 }
 
-func NewConsulPlaybookProvider(options Options) *ConsulPlaybookProvider {
+func NewConsulPlaybookProvider(consulAddress, consulKey string, variables map[string]string) *ConsulPlaybookProvider {
 	return &ConsulPlaybookProvider{
-		consulAddress: options.consul,
-		consulKey:     options.playbook,
-		variables: 		 options.variables,
+		consulAddress: consulAddress,
+		consulKey:     consulKey,
+		variables:     variables,
 	}
 }
 

--- a/sql_runner/main.go
+++ b/sql_runner/main.go
@@ -154,9 +154,9 @@ func processFlags() Options {
 // based on flags passed in
 func PlaybookProviderFromOptions(options Options) (PlaybookProvider, error) {
 	if options.consul != "" {
-		return NewConsulPlaybookProvider(options), nil
+		return NewConsulPlaybookProvider(options.consul, options.playbook, options.variables), nil
 	} else if options.playbook != "" {
-		return NewYAMLFilePlaybookProvider(options), nil
+		return NewYAMLFilePlaybookProvider(options.playbook, options.variables), nil
 	} else {
 		return nil, errors.New("Cannot determine provider for playbook")
 	}

--- a/sql_runner/main.go
+++ b/sql_runner/main.go
@@ -154,9 +154,9 @@ func processFlags() Options {
 // based on flags passed in
 func PlaybookProviderFromOptions(options Options) (PlaybookProvider, error) {
 	if options.consul != "" {
-		return NewConsulPlaybookProvider(options.consul, options.playbook), nil
+		return NewConsulPlaybookProvider(options), nil
 	} else if options.playbook != "" {
-		return NewYAMLFilePlaybookProvider(options.playbook), nil
+		return NewYAMLFilePlaybookProvider(options), nil
 	} else {
 		return nil, errors.New("Cannot determine provider for playbook")
 	}

--- a/sql_runner/options.go
+++ b/sql_runner/options.go
@@ -26,11 +26,12 @@ func (i *CLIVariables) String() string {
 }
 
 func (i *CLIVariables) Set(value string) error {
-	var split = strings.SplitN(value, "=", 2)
-	if len(split) > 1 {
-		key := split[0]
-		val := split[1]
-		(*i)[key] = val
+	var split = strings.Split(value, ",")
+
+	for value := range split {
+		kv := strings.SplitN(split[value], "=", 2)
+
+		(*i)[kv[0]] = kv[1]
 	}
 	return nil
 }

--- a/sql_runner/options.go
+++ b/sql_runner/options.go
@@ -13,6 +13,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -30,6 +31,10 @@ func (i *CLIVariables) Set(value string) error {
 
 	for value := range split {
 		kv := strings.SplitN(split[value], "=", 2)
+
+		if len(kv) != 2 {
+			return errors.New("Invalid size for key, value, key value should be in the key=value format")
+		}
 
 		(*i)[kv[0]] = kv[1]
 	}

--- a/sql_runner/yaml_provider.go
+++ b/sql_runner/yaml_provider.go
@@ -14,13 +14,13 @@ package main
 
 type YAMLFilePlaybookProvider struct {
 	playbookPath string
-	variables CLIVariables
+	variables    map[string]string
 }
 
-func NewYAMLFilePlaybookProvider(options Options) *YAMLFilePlaybookProvider {
+func NewYAMLFilePlaybookProvider(playbookPath string, variables map[string]string) *YAMLFilePlaybookProvider {
 	return &YAMLFilePlaybookProvider{
-		playbookPath: options.playbook,
-		variables: options.variables,
+		playbookPath: playbookPath,
+		variables:    variables,
 	}
 }
 

--- a/sql_runner/yaml_provider.go
+++ b/sql_runner/yaml_provider.go
@@ -14,11 +14,13 @@ package main
 
 type YAMLFilePlaybookProvider struct {
 	playbookPath string
+	variables CLIVariables
 }
 
-func NewYAMLFilePlaybookProvider(playbookPath string) *YAMLFilePlaybookProvider {
+func NewYAMLFilePlaybookProvider(options Options) *YAMLFilePlaybookProvider {
 	return &YAMLFilePlaybookProvider{
-		playbookPath: playbookPath,
+		playbookPath: options.playbook,
+		variables: options.variables,
 	}
 }
 
@@ -28,6 +30,6 @@ func (p YAMLFilePlaybookProvider) GetPlaybook() (*Playbook, error) {
 		return nil, err
 	}
 
-	playbook, pbErr := parsePlaybookYaml(lines)
+	playbook, pbErr := parsePlaybookYaml(lines, p.variables)
 	return &playbook, pbErr
 }

--- a/sql_runner/yaml_utils.go
+++ b/sql_runner/yaml_utils.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/yaml.v1"
 	"regexp"
 	"strings"
+	"text/template"
 )
 
 var (
@@ -26,13 +27,18 @@ var (
 
 // Parses a playbook.yml to return the targets
 // to execute against and the steps to execute
-func parsePlaybookYaml(playbookBytes []byte) (Playbook, error) {
+func parsePlaybookYaml(playbookBytes []byte, variables CLIVariables) (Playbook, error) {
 	// Define and initialize the Playbook struct
 	var playbook Playbook = NewPlaybook()
 
 	// Clean up the YAML
 	cleaned := cleanYaml(playbookBytes)
-	err := yaml.Unmarshal(cleaned, &playbook)
+
+	// Run the yaml through the template engine
+	str, err := fillPlaybookTemplate(string(cleaned[:]), variables)
+
+	// Unmarshal the yaml into the playbook
+	err = yaml.Unmarshal([]byte(str), &playbook)
 
 	return playbook, err
 }
@@ -50,4 +56,18 @@ func cleanYaml(rawYaml []byte) []byte {
 		buffer.WriteString(rubyYamlRegex.ReplaceAllString(line, "${1}${2}\n"))
 	}
 	return buffer.Bytes()
+}
+
+func fillPlaybookTemplate(playbookStr string, variables CLIVariables) (string, error) {
+	t, err := template.New("playbook").Parse(playbookStr)
+	if err != nil {
+		return "", err
+	}
+
+	var filled bytes.Buffer
+	if err := t.Execute(&filled, variables); err != nil {
+		return "", err
+	}
+
+	return string(filled.String()), err
 }

--- a/sql_runner/yaml_utils.go
+++ b/sql_runner/yaml_utils.go
@@ -27,7 +27,7 @@ var (
 
 // Parses a playbook.yml to return the targets
 // to execute against and the steps to execute
-func parsePlaybookYaml(playbookBytes []byte, variables CLIVariables) (Playbook, error) {
+func parsePlaybookYaml(playbookBytes []byte, variables map[string]string) (Playbook, error) {
 	// Define and initialize the Playbook struct
 	var playbook Playbook = NewPlaybook()
 
@@ -69,5 +69,5 @@ func fillPlaybookTemplate(playbookStr string, variables CLIVariables) (string, e
 		return "", err
 	}
 
-	return string(filled.String()), err
+	return filled.String(), err
 }

--- a/sql_runner/yaml_utils.go
+++ b/sql_runner/yaml_utils.go
@@ -58,7 +58,7 @@ func cleanYaml(rawYaml []byte) []byte {
 	return buffer.Bytes()
 }
 
-func fillPlaybookTemplate(playbookStr string, variables CLIVariables) (string, error) {
+func fillPlaybookTemplate(playbookStr string, variables map[string]string) (string, error) {
 	t, err := template.New("playbook").Parse(playbookStr)
 	if err != nil {
 		return "", err

--- a/sql_runner/yaml_utils_test.go
+++ b/sql_runner/yaml_utils_test.go
@@ -52,7 +52,6 @@ func TestCleanYaml(t *testing.T) {
 	assert.Equal("\n", cleanYamlStr)
 }
 
-
 func TestTemplateYaml(t *testing.T) {
 	assert := assert.New(t)
 

--- a/sql_runner/yaml_utils_test.go
+++ b/sql_runner/yaml_utils_test.go
@@ -20,7 +20,7 @@ import (
 func TestParsePlaybookYaml(t *testing.T) {
 	assert := assert.New(t)
 
-	playbook, err := parsePlaybookYaml(nil)
+	playbook, err := parsePlaybookYaml(nil, nil)
 	assert.Nil(err)
 	assert.NotNil(playbook)
 	assert.Equal(0, len(playbook.Targets))
@@ -30,7 +30,7 @@ func TestParsePlaybookYaml(t *testing.T) {
 	assert.Nil(err1)
 	assert.NotNil(playbookBytes)
 
-	playbook, err = parsePlaybookYaml(playbookBytes)
+	playbook, err = parsePlaybookYaml(playbookBytes, nil)
 	assert.Nil(err)
 	assert.NotNil(playbook)
 	assert.Equal(2, len(playbook.Targets))
@@ -50,4 +50,26 @@ func TestCleanYaml(t *testing.T) {
 
 	cleanYamlStr = string(cleanYaml(nil))
 	assert.Equal("\n", cleanYamlStr)
+}
+
+
+func TestTemplateYaml(t *testing.T) {
+	assert := assert.New(t)
+
+	playbookBytes, err1 := loadLocalFile("../integration/resources/good-postgres-with-template.yml")
+	assert.Nil(err1)
+
+	var m map[string]string = make(map[string]string)
+
+	m["password"] = "qwerty123"
+	m["username"] = "animoto"
+	m["host"] = "theinternetz"
+
+	playbook, err := parsePlaybookYaml(playbookBytes, CLIVariables(m))
+
+	assert.Nil(err)
+
+	assert.Equal("qwerty123", playbook.Targets[0].Password)
+	assert.Equal("animoto", playbook.Targets[0].Username)
+	assert.Equal("theinternetz", playbook.Targets[0].Host)
 }


### PR DESCRIPTION
I was recently recommended by @lritter to consider using this tool for some adhoc queries we need to run regularly and I ended up really liking it. Simple, clean, functional, we're already snowplow users and a perfect match.

But I wasn't happy with the idea of all of my hosts and password being hosted along with the playbooks, so to fix this I changed it so that the `-var` flag will pass into a playbook similar to the way it does for sql templates, then we can get our passwords out of local config without worrying the tool. 

I also found out that based on:
https://github.com/snowplow/sql-runner/blob/master/sql_runner/options.go#L28-L36

there's a limit of only a single key=value pair in the `-var` flag, I extended this so that it will load any number of vars via comma separation (`key=value,key2=value2`)

Pretty new to go, please do pick it apart. 