### PR TITLE
Update README markdown in accordance with CommonMark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SQL Runner
 
-[![Build Status] [travis-image]][travis] [![Coveralls][coveralls-image]][coveralls] [![Release][release-image]][releases] [![License][license-image]][license]
+[![Build Status][travis-image]][travis] [![Coveralls][coveralls-image]][coveralls] [![Release][release-image]][releases] [![License][license-image]][license]
 
 ## Overview
 
@@ -8,9 +8,9 @@ Run playbooks of SQL scripts in series and parallel on Amazon Redshift and Postg
 
 Used with **[Snowplow] [snowplow]** for scheduled SQL-based transformations of event stream data.
 
-|  **[Devops Guide] [devops-guide]**     | **[Analysts Guide] [analysts-guide]**     | **[Developers Guide] [developers-guide]**     |
+|  **[Devops Guide][devops-guide]**     | **[Analysts Guide][analysts-guide]**     | **[Developers Guide][developers-guide]**     |
 |:--------------------------------------:|:-----------------------------------------:|:---------------------------------------------:|
-|  [![i1] [devops-image]] [devops-guide] | [![i2] [analysts-image]] [analysts-guide] | [![i3] [developers-image]] [developers-guide] |
+|  [![i1][devops-image]][devops-guide] | [![i2][analysts-image]][analysts-guide] | [![i3][developers-image]][developers-guide] |
 
 ## Quickstart
 
@@ -26,7 +26,7 @@ Assuming you are running on **64bit Linux**:
 
 SQL Runner is copyright 2015-2017 Snowplow Analytics Ltd.
 
-Licensed under the **[Apache License, Version 2.0] [license]** (the "License");
+Licensed under the **[Apache License, Version 2.0][license]** (the "License");
 you may not use this software except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software


### PR DESCRIPTION
Since GitHubs markdown is very specific, images and links where not showing as intended:
![screen shot 2017-08-17 at 10 12 02](https://user-images.githubusercontent.com/8283992/29402605-e0bde2c8-8335-11e7-98d2-a6f9b5c64ae2.png)

This PR will fix  this and the readme will be shown correctly:
![screen shot 2017-08-17 at 10 15 03](https://user-images.githubusercontent.com/8283992/29402693-35fa6158-8336-11e7-8507-aa240ea43bef.png)
